### PR TITLE
feat: reaction viewer

### DIFF
--- a/src/Generic.tsx
+++ b/src/Generic.tsx
@@ -328,6 +328,11 @@ export const app = {
       `[FUNCTIONS] Tried to run uninitialised function openMessage (args: ${m})`,
     );
   },
+  openViewReactions: (m: Message | null, e: string | null) => {
+    console.log(
+      `[FUNCTIONS] Tried to run uninitialised function openViewReaction (args: ${m}, ${e})`
+    );
+  },
   openChannelContextMenu: (c: Channel | null) => {
     console.log(
       `[FUNCTIONS] Tried to run uninitialised function openChannelContextMenu (args: ${c})`,

--- a/src/Modals.tsx
+++ b/src/Modals.tsx
@@ -32,6 +32,7 @@ import {
   ServerSettingsSheet,
   SettingsSheet,
   StatusSheet,
+  ViewReactionsSheet
 } from '@clerotri/components/sheets';
 
 // Modals appear to break on the new architecture unless you wrap them in a View. see also https://github.com/react-navigation/react-navigation/issues/12301#issuecomment-2501692557
@@ -173,6 +174,7 @@ export const Modals = observer(() => {
       <MessageMenuSheet />
       <ChannelMenuSheet />
       <StatusSheet />
+      <ViewReactionsSheet />
       <ProfileSheet />
       <ReportSheet />
       <ChannelInfoSheet />

--- a/src/components/common/BottomSheet.tsx
+++ b/src/components/common/BottomSheet.tsx
@@ -1,5 +1,5 @@
 import {useContext, useMemo} from 'react';
-import {StyleSheet} from 'react-native';
+import {StyleSheet, Text} from 'react-native';
 
 import BottomSheetCore, {
   BottomSheetBackdrop,
@@ -10,7 +10,7 @@ import {observer} from 'mobx-react-lite';
 import {commonValues, Theme, ThemeContext} from '@clerotri/lib/themes';
 
 export const BottomSheet = observer(
-  ({sheetRef, children}: {sheetRef: any; children: any}) => {
+  ({sheetRef, outerScroll, children}: {sheetRef: any; outerScroll?: 'auto' | 'none' | 'custom'; children: any}) => {
     const {currentTheme} = useContext(ThemeContext);
     const localStyles = useMemo(
       () => generateLocalStyles(currentTheme),
@@ -28,8 +28,15 @@ export const BottomSheet = observer(
         backdropComponent={BottomSheetBackdrop}
         style={localStyles.sheet}
         backgroundStyle={localStyles.sheetBackground}
-        handleIndicatorStyle={localStyles.handleIndicator}>
-        <BottomSheetScrollView>{children}</BottomSheetScrollView>
+        handleIndicatorStyle={localStyles.handleIndicator}
+        enableContentPanningGesture={outerScroll != 'none'}>
+        {outerScroll == 'none' ? (
+          <BottomSheetView style={{ flexDirection: 'column', flex: 1 }}>{children}</BottomSheetView>
+        ) : outerScroll == 'custom' ? (
+          <>{children}</>
+        ) : (
+          <BottomSheetScrollView>{children}</BottomSheetScrollView>
+        )}
       </BottomSheetCore>
     );
   },

--- a/src/components/common/messaging/MessageReactions.tsx
+++ b/src/components/common/messaging/MessageReactions.tsx
@@ -39,6 +39,9 @@ export const MessageReactions = observer(
                       : msg.unreact(r.emoji)
                     : showToast('You cannot react to this message.');
                 })}
+                onLongPress={action(() => {
+                  app.openViewReactions(msg, r.emoji);
+                })}
                 style={{
                   padding: commonValues.sizes.small,
                   borderRadius: commonValues.sizes.small,

--- a/src/components/common/messaging/MessageReactions.tsx
+++ b/src/components/common/messaging/MessageReactions.tsx
@@ -5,6 +5,7 @@ import {observer} from 'mobx-react-lite';
 
 import type {Message} from 'revolt.js';
 
+import {app} from '@clerotri/Generic';
 import {client} from '@clerotri/lib/client';
 import {Text} from '@clerotri/components/common/atoms';
 import {Image} from '@clerotri/crossplat/Image';

--- a/src/components/sheets/ViewReactionsSheet.tsx
+++ b/src/components/sheets/ViewReactionsSheet.tsx
@@ -1,0 +1,134 @@
+import { useRef, useState, useContext } from 'react';
+import { View, Text, Image, ScrollView, Pressable, StyleSheet, ViewStyle, StyleProp, TouchableOpacity } from 'react-native';
+import { observer } from 'mobx-react-lite';
+
+import type BottomSheetCore from '@gorhom/bottom-sheet';
+import { BottomSheet } from '@clerotri/components/common/BottomSheet';
+import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
+import { app, setFunction } from '@clerotri/Generic';
+import { Message } from 'revolt.js';
+import { client } from '@clerotri/lib/client';
+import { commonValues, ThemeContext, Theme } from '@clerotri/lib/themes';
+import { Style } from 'util';
+import { MiniProfile } from '../common/profile';
+
+type ReactionPile = {
+  emoji: string;
+  reactors: string[];
+};
+
+const Reactors = observer(({message, reaction, style}: {message: Message | null, reaction: string | null, style: StyleProp<ViewStyle>}) => {
+  if (!message || !reaction || !message.reactions.get(reaction)) return <></>;
+
+  const rawReactors = Array.from(message.reactions.get(reaction)!.values());
+  let reactors: string[] = [];
+  for (const r of rawReactors) {
+    reactors.push(r);
+  }
+
+  return (<>
+    {reactors.map((e) => {
+      const user = client.users.get(e);
+      if (user && user.relationship != 'Blocked')
+        return <TouchableOpacity
+          style={style}
+          onPress={() => {
+            app.openProfile(user);
+          }}
+        >
+          <MiniProfile key={`viewreactions-content-${user._id}`} user={user} />
+        </TouchableOpacity>
+    })}
+  </>);
+});
+
+export const ViewReactionsSheet = observer(() => {
+  const {currentTheme} = useContext(ThemeContext);
+  const localStyles = generateLocalStyles(currentTheme);
+
+  const [message, setMessage] = useState(null as Message | null);
+  const [reaction, setReaction] = useState(null as string | null);
+  const currentReaction = () => message && (reaction && message.reactions.get(reaction) && message.reactions.get(reaction)!.size > 0 && reaction) || message?.reactions.keys().next()?.toString();
+
+  const sheetRef = useRef<BottomSheetCore>(null);
+
+  setFunction('openViewReactions', async (m: Message | null, emoji: string) => {
+    setMessage(m);
+    setReaction(emoji);
+    m ? sheetRef.current?.expand() : sheetRef.current?.close();
+  });
+
+  // const [messageReactions, setMessageReactions] = useState([] as ReactionPile[] | null);
+
+  const rawReactions = Array.from(message?.reactions ?? []);
+  let reactions: ReactionPile[] = [];
+  for (const r of rawReactions) {
+    reactions.push({emoji: r[0], reactors: Array.from(r[1])});
+  }
+
+  return (
+    <BottomSheet outerScroll={'custom'} sheetRef={sheetRef}>
+      {!message ? <></> : (
+        <View style={{ paddingHorizontal: 16, height: 200}}>
+          <ScrollView horizontal style={{
+            marginVertical: commonValues.sizes.small,
+            maxHeight: 36,
+          }}>
+            {reactions?.map((r) => {
+              return (
+                <Pressable
+                  key={`viewreactions-reaction-${r.emoji}`}
+                  style={{
+                    padding: commonValues.sizes.small,
+                    borderRadius: commonValues.sizes.small,
+                    borderColor: currentReaction() && r.emoji == currentReaction()
+                      ? currentTheme.accentColor
+                      : currentTheme.backgroundTertiary,
+                    backgroundColor: currentTheme.backgroundSecondary,
+                    borderWidth: commonValues.sizes.xs,
+                    marginEnd: commonValues.sizes.small,
+                    marginVertical: commonValues.sizes.xs,
+                  }}
+                  onPress={() => setReaction(r.emoji)}
+                >
+                  <View style={{ flexDirection: 'row' }}>
+                    {r.emoji.length > 6 && (
+                      <Image
+                        style={{minHeight: 20, minWidth: 20}}
+                        source={{
+                          uri: `${client.configuration?.features.autumn.url}/emojis/${r.emoji}`,
+                        }}
+                      />
+                    )}
+                    <Text key={`viewreactions-reaction-${r.emoji}-label`} style={{ color: currentTheme.foregroundPrimary }}>
+                      {r.emoji.length <= 6 && r.emoji} {r.reactors.length}
+                    </Text>
+                  </View>
+                </Pressable>
+              );
+            })}
+          </ScrollView>
+          <BottomSheetScrollView>
+            <Reactors message={message} reaction={reaction} style={localStyles.reactorButton} />
+          </BottomSheetScrollView>
+        </View>
+      )}
+    </BottomSheet>
+  );
+});
+
+const generateLocalStyles = (currentTheme: Theme) => {
+  return StyleSheet.create({
+    reactorButton: {
+      height: 50,
+      width: '100%',
+      alignItems: 'center',
+      flexDirection: 'row',
+      backgroundColor: currentTheme.backgroundPrimary,
+      borderRadius: commonValues.sizes.medium,
+      paddingInline: 10,
+      marginVertical: commonValues.sizes.small,
+      color: currentTheme.foregroundPrimary
+    },
+  });
+};

--- a/src/components/sheets/index.ts
+++ b/src/components/sheets/index.ts
@@ -11,3 +11,4 @@ export {ServerInviteSheet} from './ServerInviteSheet';
 export {ServerSettingsSheet} from './ServerSettingsSheet';
 export {SettingsSheet} from './SettingsSheet';
 export {StatusSheet} from './StatusSheet';
+export {ViewReactionsSheet} from './ViewReactionsSheet';

--- a/src/lib/utils/utils.ts
+++ b/src/lib/utils/utils.ts
@@ -10,11 +10,14 @@ import {
   DEFAULT_MESSAGE_LOAD_COUNT,
   DISCOVER_URL,
   RE_BOT_INVITE,
+  RE_CUSTOM_EMOJI,
   RE_INVITE,
+  RE_UNICODE_EMOJI,
   WIKI_URL,
 } from '@clerotri/lib/consts';
 import {storage} from '@clerotri/lib/storage';
 import {EmojiPacks} from '@clerotri/lib/types';
+import { RevoltEmojiDictionary } from '@clerotri/lib/consts';
 
 /**
  * Sleep for the specified amount of milliseconds before continuing.
@@ -251,3 +254,12 @@ export function unicodeEmojiURL(emoji: string, pack: EmojiPacks = 'mutant') {
   )}.svg?rev=${REVISION}`;
 }
 // </from>
+
+export function findEmojiName(emoji: string) {
+  // 'emoji' can either be an emoji character, or the id of the custom emoji
+  if (emoji.match(RE_UNICODE_EMOJI))
+    return Object.keys(RevoltEmojiDictionary).find(key => RevoltEmojiDictionary[key] === emoji);
+  else if ((':'+emoji+':').match(RE_CUSTOM_EMOJI))
+    return client.emojis.get(emoji)?.name;
+  return null;
+}


### PR DESCRIPTION
As requested in https://github.com/upryzing/clerotri/pull/45#pullrequestreview-2668790110, originally as part of https://github.com/upryzing/clerotri/pull/45

Adds a reaction viewer, displaying which users reacted with which emojis by long-pressing a reaction under a message.

## Please make sure to check the following tasks before opening and submitting a PR

- [X] I understand and have followed the https://github.com/revoltchat/revolt/discussions/282
- [X] I have tested my changes locally and they are working as intended
- [X] These changes do not have any notable side effects on other Revolt projects